### PR TITLE
Kill Gazebo Server After Launch

### DIFF
--- a/src/lazershark_sim/launch/lazershark_world.launch.py
+++ b/src/lazershark_sim/launch/lazershark_world.launch.py
@@ -1,14 +1,16 @@
 from pathlib import Path
+import subprocess
 
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-from launch.actions import IncludeLaunchDescription
+from launch.actions import RegisterEventHandler
+from launch.actions import IncludeLaunchDescription, ExecuteProcess
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PathJoinSubstitution
+from launch.event_handlers import OnShutdown
 
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
@@ -62,6 +64,12 @@ def generate_launch_description():
     #     condition=IfCondition(LaunchConfiguration("rviz")),
     # )
 
+    die_gazebo_die = RegisterEventHandler(
+        OnShutdown(
+            on_shutdown=lambda event, context: ExecuteProcess(cmd=["pkill " " -9 " " -f " "\"gz sim\""], shell=True)
+        )
+    )
+
     return LaunchDescription(
         [
             # DeclareLaunchArgument(
@@ -70,6 +78,7 @@ def generate_launch_description():
             gz_sim_server,
             gz_sim_gui,
             lazer_shark,
+            die_gazebo_die,
             # rviz,
         ]
     )


### PR DESCRIPTION
I noticed that the extremely broken and frustrating ROS2 launch system leaves Gazebo server hanging around. This causes simulations to fail with a "jumping sub" in subsequent runs. This hack ensures the launch system kills Gazebo dead. 